### PR TITLE
Add version to AEXML dependency

### DIFF
--- a/Kml.swift.podspec
+++ b/Kml.swift.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
 
   s.source = { :git => 'https://github.com/asus4/Kml.swift.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
-  s.dependency "AEXML"
+  s.dependency 'AEXML', '~> 2.1.0'
 
 end


### PR DESCRIPTION
This pull request resolves issue #5 by adding a version to the AEXML dependency.
