### PR TITLE
Add support for reading simple ExtendedData tag

### DIFF
--- a/Source/KML.swift
+++ b/Source/KML.swift
@@ -466,6 +466,7 @@ open class KMLAnnotation: NSObject, MKAnnotation {
     open var title: String?
     open var subtitle: String?
     open var style: KMLStyle?
+    open var placemark: KMLPlacemark?
 
     init(_ coordinate: CLLocationCoordinate2D) {
         self.coordinate = coordinate
@@ -622,6 +623,7 @@ open class KMLDocument: KMLElement {
                 annotation.title = pointPlacemark.name
                 annotation.subtitle = pointPlacemark.description
                 annotation.style = pointPlacemark.style
+                annotation.placemark = pointPlacemark
 
                 self.annotations.append(annotation)
             }

--- a/Source/KML.swift
+++ b/Source/KML.swift
@@ -29,6 +29,8 @@ public enum KMLTag: String {
     case Folder
     case Placemark
     case Icon
+    case ExtendedData
+    case Data
 
     public var str: String {
         return self.rawValue
@@ -50,7 +52,9 @@ public struct KMLConfig {
         KMLTag.Folder.str: KMLElement.self,
         KMLTag.Placemark.str: KMLPlacemark.self,
         KMLTag.Icon.str: KMLIcon.self,
-        KMLTag.IconStyle.str: KMLIconStyle.self
+        KMLTag.IconStyle.str: KMLIconStyle.self,
+        KMLTag.ExtendedData.str: KMLExtendedData.self,
+        KMLTag.Data.str: KMLData.self
     ]
 }
 
@@ -390,6 +394,7 @@ open class KMLPlacemark: KMLElement {
     open var lineString: KMLLineString?
     open var polygon: KMLPolygon?
     open var style: KMLStyle?
+    open var extendedData: KMLExtendedData?
 
     public required init(_ element: AEXMLElement) {
         let style = element["styleUrl"].string
@@ -409,6 +414,43 @@ open class KMLPlacemark: KMLElement {
         } else if let polygonGeometry = findElement(KMLPolygon.self) {
             polygon = polygonGeometry
         }
+        
+        extendedData = findElement(KMLExtendedData.self)
+    }
+}
+
+// MARK: - Extended Data
+
+open class KMLExtendedData: KMLElement {
+    open var data: [String: KMLData] = [:]
+    
+    public required init(_ element: AEXMLElement) {
+        super.init(element)
+        for dataElement in findElements(KMLData.self) {
+            self.data[dataElement.dataName] = dataElement
+        }
+    }
+}
+
+open class KMLData: KMLElement {
+    open var dataName: String = ""
+    open var displayName: String?
+    open var value: String?
+    
+    public required init(_ element: AEXMLElement) {
+        self.dataName = element.attributes["name"] ?? ""
+        
+        for child: AEXMLElement in element.children {
+            switch child.name {
+            case "displayName":
+                displayName = child.string
+            case "value":
+                value = child.string
+            default:
+                break
+            }
+        }
+        super.init(element)
     }
 }
 

--- a/Source/KML.swift
+++ b/Source/KML.swift
@@ -81,8 +81,9 @@ open class KMLElement {
         let lines: [String] = element.string.components(separatedBy: CharacterSet.whitespacesAndNewlines)
         for line in lines {
             let points: [String] = line.components(separatedBy: ",")
-            assert(points.count >= 2, "points lenth is \(points)")
-            coordinates.append(CLLocationCoordinate2DMake(atof(points[1]), atof(points[0])))
+            if points.count >= 2 {
+                coordinates.append(CLLocationCoordinate2DMake(atof(points[1]), atof(points[0])))
+            }
         }
         return coordinates
     }


### PR DESCRIPTION
Added support for untyped ExtendedData, as per:
https://developers.google.com/kml/documentation/extendeddata

In your doc.kml:
```
<Placemark>
  ...
  <ExtendedData>
    <Data name="foo">
      <displayName>Display</displayName>
      <value>bar</value>
    </Data>
  </ExtendedData>
  ...
</Placemark>
```

Swift code to access the extended data:
```
let value = placemark.extendedData?.data["foo"]?.value
let displayName = placemark.extendedData?.data["foo"]?.displayName
```