### PR TITLE
Updated pod spec to get AEXML updates

### DIFF
--- a/Kml.swift.podspec
+++ b/Kml.swift.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/asus4/Kml.swift.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
   
-  s.dependency 'AEXML',   '4.3.0'
+  s.dependency 'AEXML',   '~>4.3.0'
 
 end


### PR DESCRIPTION
Updated the pod spec to get the last version of AEXML.

Could you please release tag 0.3.1 and update the pod spec in the CocoaPods repo?